### PR TITLE
Generic joystick polling rate increase to 200 Hz

### DIFF
--- a/WiinUPro/Controls/JoyControl.xaml.cs
+++ b/WiinUPro/Controls/JoyControl.xaml.cs
@@ -446,8 +446,8 @@ namespace WiinUPro
                 }
                 catch { /* Failed to read */ }
 
-                // Reads 20 times a second
-                Thread.Sleep(50);
+                // Reads 200 times a second
+                Thread.Sleep(5);
             }
         }
 


### PR DESCRIPTION
Just a hotfix because generic joysticks were so unresponsive before at 20 Hz that they were basically unusable.

The higher polling rate does burn off a little bit more CPU, but only while the joystick's config tab is selected. 
Going to the Home tab makes the CPU consumption fine.

Later on, a polling rate option could be added, but for now this is fine for most use cases.