### PR TITLE
Added, primarily, rumble device saving in profile and auto adding of XInput devices.

### DIFF
--- a/WiinUPro/AppPrefs.cs
+++ b/WiinUPro/AppPrefs.cs
@@ -62,7 +62,7 @@ namespace WiinUPro
         public bool useExclusiveMode;
         public bool useToshibaMode;
         public bool suppressConnectionLost;
-        public int autoAddXInputDevices;
+        public bool autoAddXInputDevices;
 
         public static string ToFileName(string text)
         {

--- a/WiinUPro/Assignments/AssignmentProfile.cs
+++ b/WiinUPro/Assignments/AssignmentProfile.cs
@@ -10,6 +10,7 @@ namespace WiinUPro
         public List<AssignmentPair> GreenAssignments;
         public AssignmentProfile SubProfile;
         public string SubName;
+        public bool[] RumbleDevices = new bool[4];
 
         public AssignmentProfile()
         {

--- a/WiinUPro/Controls/BaseControl.cs
+++ b/WiinUPro/Controls/BaseControl.cs
@@ -41,7 +41,7 @@ namespace WiinUPro
             var element = sender as FrameworkElement;
             var tag = element == null ? "" : _inputPrefix + element.Tag as string;
 
-            // TOOD: Solve issue where this is being triggered twice for the guitar
+            // TODO: Solve issue where this is being triggered twice for the guitar
             // Open input assignment window
             if (OnInputSelected != null && tag != null)
             {

--- a/WiinUPro/Controls/DeviceStatus.xaml.cs
+++ b/WiinUPro/Controls/DeviceStatus.xaml.cs
@@ -35,6 +35,7 @@ namespace WiinUPro
         public Action<DeviceStatus, ControllerType> TypeUpdated;
         public Action<DeviceStatus> CloseTab;
         public Action<DeviceStatus, DevicePrefs> OnPrefsChange;
+        public Action<DeviceStatus, bool[]> OnRumbleSubscriptionChange;
 
         public ImageSource Icon { get { return icon.Source; } }
 
@@ -76,6 +77,7 @@ namespace WiinUPro
                 Ninty.OnTypeChange += Ninty_OnTypeChange;
                 Ninty.OnDisconnect += Ninty_OnDisconnect;
                 Ninty.OnPrefsChange += Ninty_OnPrefsChange;
+                Ninty.OnRumbleSubscriptionChange += Ninty_OnRumbleSubscriptionChange;
 
                 // Use saved icon if there is one
                 var prefs = AppPrefs.Instance.GetDevicePreferences(Info.DevicePath);
@@ -138,6 +140,11 @@ namespace WiinUPro
             }
 
             OnPrefsChange?.Invoke(this, prefs);
+        }
+
+        private void Ninty_OnRumbleSubscriptionChange(bool[] rumbleSubscriptions)
+        {
+            OnRumbleSubscriptionChange?.Invoke(this, rumbleSubscriptions);
         }
 
         public void UpdateType(ControllerType type)

--- a/WiinUPro/Controls/NintyControl.xaml.cs
+++ b/WiinUPro/Controls/NintyControl.xaml.cs
@@ -18,6 +18,7 @@ namespace WiinUPro
         public event TypeUpdate OnTypeChange;       // Called on extension changes
         public event Action OnDisconnect;           // Called when disconnected
         public event Action<DevicePrefs> OnPrefsChange;
+        public event Action<bool[]> OnRumbleSubscriptionChange;
 
         internal CommonStream _stream;               // Controller stream to the device
         internal Nintroller _nintroller;            // Physical Controller Device
@@ -407,10 +408,7 @@ namespace WiinUPro
                     }
                 }
                 _rumbleSubscriptions = loadedProfile.RumbleDevices;
-                if (AppPrefs.Instance.autoAddXInputDevices)
-                {
-                    MainWindow._instance.AddXInput(_rumbleSubscriptions);
-                }
+                OnRumbleSubscriptionChange?.Invoke(_rumbleSubscriptions);
             }
         }
 
@@ -646,10 +644,7 @@ namespace WiinUPro
             }
 
             _rumbleSubscriptions = win.Result;
-            if (AppPrefs.Instance.autoAddXInputDevices)
-            {
-                MainWindow._instance.AddXInput(_rumbleSubscriptions);
-            }
+            OnRumbleSubscriptionChange?.Invoke(_rumbleSubscriptions);
         }
 
         private void btnPrefs_Click(object sender, RoutedEventArgs e)

--- a/WiinUPro/Windows/MainWindow.xaml
+++ b/WiinUPro/Windows/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WiinUPro"
         mc:Ignorable="d"
-        Title="WiinUPro" Height="520" Width="484" MinWidth="480" MinHeight="320" Icon="/WiinUPro;component/app.ico" Background="{StaticResource BackgroundMain}" Loaded="Window_Loaded" Closing="Window_Closing">
+        Title="WiinUPro" Height="520" Width="500" MinWidth="480" MinHeight="320" Icon="/WiinUPro;component/app.ico" Background="{StaticResource BackgroundMain}" Loaded="Window_Loaded" Closing="Window_Closing">
     <Grid>
         <TabControl x:Name="tabControl" Margin="10" Background="{StaticResource BackgroundSub}" >
             <TabControl.Resources>
@@ -55,10 +55,11 @@
                     <GroupBox x:Name="settingsGroup" Header="Settings" Margin="267,26,4,169.5" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <CheckBox x:Name="settingAutoStart" Content="Auto Start" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Style="{StaticResource CheckBoxStyle}" Click="settingAutoStart_Checked"/>
-                            <CheckBox x:Name="settingStartMinimized" Content="Start Minimized" HorizontalAlignment="Left" Margin="10,30,0,0" VerticalAlignment="Top" IsEnabled="False" Style="{StaticResource CheckBoxStyle}" Click="settingStartMinimized_Checked"/>
+                            <CheckBox x:Name="settingStartMinimized" Content="Start Minimized" HorizontalAlignment="Left" Margin="10,30,0,0" VerticalAlignment="Top" Style="{StaticResource CheckBoxStyle}" Click="settingStartMinimized_Checked"/>
                             <CheckBox x:Name="settingExclusiveMode" Content="Use Exclusive Mode" HorizontalAlignment="Left" Margin="10,50,0,0" VerticalAlignment="Top" Style="{StaticResource CheckBoxStyle}" Click="settingExclusiveMode_Checked"/>
                             <CheckBox x:Name="settingToshibaMode" Content="Use Toshiba Mode" HorizontalAlignment="Left" Margin="10,70,0,0" VerticalAlignment="Top" Style="{StaticResource CheckBoxStyle}" Click="settingToshibaMode_Checked"/>
                             <CheckBox x:Name="settingSuppressLostConn" Content="Hide Connection Errors" HorizontalAlignment="Left" Margin="10,90,0,0" VerticalAlignment="Top" Style="{StaticResource CheckBoxStyle}" Click="settingSuppressLostConn_Checked"/>
+                            <CheckBox x:Name="settingAutoAddXInputDevices" Content="Auto Add XInput Devices" HorizontalAlignment="Left" Margin="10,110,0,0" VerticalAlignment="Top" Style="{StaticResource CheckBoxStyle}" Click="settingAutoAddXInputDevices_Checked"/>
                         </Grid>
                     </GroupBox>
                     <GroupBox x:Name="xinputGroup" Header="XInput Devices" Margin="267,0,4,7.5" Style="{StaticResource GroupBoxStyle}" Height="159" VerticalAlignment="Bottom">

--- a/WiinUPro/Windows/MainWindow.xaml.cs
+++ b/WiinUPro/Windows/MainWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace WiinUPro
             }
         }
 
-        private static MainWindow _instance;
+        public static MainWindow _instance;
         
         List<DeviceStatus> _availableDevices;
         DateTime _lastRefreshTime;
@@ -370,8 +370,65 @@ namespace WiinUPro
         {
             AppPrefs.Instance.suppressConnectionLost = settingSuppressLostConn.IsChecked ?? false;
         }
+        private void settingAutoAddXInputDevices_Checked(object sender, RoutedEventArgs e)
+        {
+            AppPrefs.Instance.autoAddXInputDevices = settingAutoAddXInputDevices.IsChecked ?? false;
+        }
 
         #endregion
+
+        public void AddXInput(bool[] rumbleSub)
+        {
+            int n = 3;
+            for (; n > -1; n--)
+            {
+                if (rumbleSub[n])
+                {
+                    Console.WriteLine(n.ToString());
+                    break;
+                }
+            }
+            
+            if (n > -1 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_A))
+            {
+                bool connected = false;
+                for (int i = 0; i < 4; i++)
+                {
+                    ScpDirector.Access.SetModifier(i);
+                    connected = ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_A);
+                    if (connected) break;
+                }
+
+                if (connected)
+                {
+                    btnRemoveXinput.IsEnabled = true;
+                    xlabel1.Content = "Device 1: Auto Connected";
+                }
+            }
+            if (n > 0 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_B))
+            {
+                if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_B))
+                {
+                    xlabel2.Content = "Device 2: Auto Connected";
+                }
+            }
+            if (n > 1 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_C))
+            {
+                if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_C))
+                {
+                    xlabel3.Content = "Device 3: Auto Connected";
+                }
+            }
+            if (n > 2 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_D))
+            {
+                if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_D))
+                {
+                    btnAddXinput.IsEnabled = false;
+                    xlabel4.Content = "Device 4: Auto Connected";
+                }
+            }
+
+        }
 
         private void btnAddXinput_Click(object sender, RoutedEventArgs e)
         {
@@ -485,11 +542,15 @@ namespace WiinUPro
             // Check Suppress Connection Lost
             settingSuppressLostConn.IsChecked = AppPrefs.Instance.suppressConnectionLost;
 
+            // Check Auto Add Xinput Devices
+            settingAutoAddXInputDevices.IsChecked = AppPrefs.Instance.autoAddXInputDevices;
+
             // Check for Start Minimized
             if (AppPrefs.Instance.startMinimized)
             {
                 settingStartMinimized.IsChecked = true;
-                // TOOD: Minimize
+                // TODO: Minimize to system tray instead.
+                WindowState = WindowState.Minimized;
             }
 
             // Check Exclusive Mode

--- a/WiinUPro/Windows/MainWindow.xaml.cs
+++ b/WiinUPro/Windows/MainWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace WiinUPro
             }
         }
 
-        public static MainWindow _instance;
+        private static MainWindow _instance;
         
         List<DeviceStatus> _availableDevices;
         DateTime _lastRefreshTime;
@@ -161,7 +161,7 @@ namespace WiinUPro
                             }
                         }
                     };
-
+                    status.OnRumbleSubscriptionChange = RumbleSettingsChanged;
                     _availableDevices.Add(status);
                     statusStack.Children.Add(status);
 
@@ -377,57 +377,58 @@ namespace WiinUPro
 
         #endregion
 
-        public void AddXInput(bool[] rumbleSub)
+        public void RumbleSettingsChanged(DeviceStatus s, bool[] rumbleSubscriptions)
         {
-            int n = 3;
-            for (; n > -1; n--)
+            if (AppPrefs.Instance.autoAddXInputDevices)
             {
-                if (rumbleSub[n])
+                int n = 3;
+                for (; n > -1; n--)
                 {
-                    Console.WriteLine(n.ToString());
-                    break;
-                }
-            }
-            
-            if (n > -1 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_A))
-            {
-                bool connected = false;
-                for (int i = 0; i < 4; i++)
-                {
-                    ScpDirector.Access.SetModifier(i);
-                    connected = ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_A);
-                    if (connected) break;
+                    if (rumbleSubscriptions[n])
+                    {
+                        break;
+                    }
                 }
 
-                if (connected)
+                if (n > -1 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_A))
                 {
-                    btnRemoveXinput.IsEnabled = true;
-                    xlabel1.Content = "Device 1: Auto Connected";
-                }
-            }
-            if (n > 0 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_B))
-            {
-                if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_B))
-                {
-                    xlabel2.Content = "Device 2: Auto Connected";
-                }
-            }
-            if (n > 1 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_C))
-            {
-                if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_C))
-                {
-                    xlabel3.Content = "Device 3: Auto Connected";
-                }
-            }
-            if (n > 2 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_D))
-            {
-                if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_D))
-                {
-                    btnAddXinput.IsEnabled = false;
-                    xlabel4.Content = "Device 4: Auto Connected";
-                }
-            }
+                    bool connected = false;
+                    for (int i = 0; i < 4; i++)
+                    {
+                        ScpDirector.Access.SetModifier(i);
+                        connected = ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_A);
+                        if (connected) break;
+                    }
 
+                    if (connected)
+                    {
+                        btnRemoveXinput.IsEnabled = true;
+                        xlabel1.Content = "Device 1: Auto Connected";
+                    }
+                }
+                if (n > 0 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_B))
+                {
+                    if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_B))
+                    {
+                        xlabel2.Content = "Device 2: Auto Connected";
+                    }
+                }
+                if (n > 1 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_C))
+                {
+                    if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_C))
+                    {
+                        xlabel3.Content = "Device 3: Auto Connected";
+                    }
+                }
+                if (n > 2 && !ScpDirector.Access.IsConnected(ScpDirector.XInput_Device.Device_D))
+                {
+                    if (ScpDirector.Access.ConnectDevice(ScpDirector.XInput_Device.Device_D))
+                    {
+                        btnAddXinput.IsEnabled = false;
+                        xlabel4.Content = "Device 4: Auto Connected";
+                    }
+                }
+            }
         }
 
         private void btnAddXinput_Click(object sender, RoutedEventArgs e)

--- a/WiinUPro/Windows/RumbleWindow.xaml.cs
+++ b/WiinUPro/Windows/RumbleWindow.xaml.cs
@@ -22,6 +22,7 @@ namespace WiinUPro.Windows
                 xDeviceB.IsChecked = subscriptions[1];
                 xDeviceC.IsChecked = subscriptions[2];
                 xDeviceD.IsChecked = subscriptions[3];
+                Result = subscriptions;
             }
         }
 


### PR DESCRIPTION
**Changelog:**
 + Saving and loading of rumble device settings from profile for Wiimotes.*
 + Automatic adding of XInput devices based on rumble device settings for Wiimotes. (Resolving issue #36)
 + Primitive minimize on start feature.
 + Rumble settings aren’t cleared now when closing the RumbleWindow.xaml
 * Minor spelling mistake fixes (TOOD → TODO).

_*Please note that only the rumble device is saved to the configuration file, not the rumble-on-press configurations. As such issue #34 isn’t technically entirely resolved yet._

I’d assume one would ideally make a separate pull request for each added or modified feature, but I realized this too late. I plan to add additional features in the future, so I hope I did this correctly (code-wise and GitHub-wise). I’d appreciate feedback.

There’s obviously room for improvement. The code I wrote in NintyControl.xaml.cs 397-409 is merely copied (with minor variable alterations) from btnAddRumble_Click() in the same file. As such it might be better to create a function which does this in one place (and runs the autoAddXinput() function as well), as to reduce the amount of almost duplicate code.

The crude minimization feature I added would ideally be replaced by a minimization to system tray feature, but this crude minimization feature is, in my opinion, at least better than a disabled checkbox which does nothing.

Additional info regarding code modifications can be found in each respective commit comment.