### PR TITLE
Added extension specific profile functionality.

### DIFF
--- a/WiinUPro/Controls/NintyControl.xaml.cs
+++ b/WiinUPro/Controls/NintyControl.xaml.cs
@@ -659,7 +659,7 @@ namespace WiinUPro
                 };
             }
 
-            var win = new Windows.DevicePrefsWindow(prefs, _nintroller.Type.ToString());
+            var win = new Windows.DevicePrefsWindow(prefs, _nintroller.Type);
             win.ShowDialog();
 
             if (win.DoSave)

--- a/WiinUPro/Controls/NintyControl.xaml.cs
+++ b/WiinUPro/Controls/NintyControl.xaml.cs
@@ -659,7 +659,7 @@ namespace WiinUPro
                 };
             }
 
-            var win = new Windows.DevicePrefsWindow(prefs);
+            var win = new Windows.DevicePrefsWindow(prefs, _nintroller.Type.ToString());
             win.ShowDialog();
 
             if (win.DoSave)

--- a/WiinUPro/DevicePrefs.cs
+++ b/WiinUPro/DevicePrefs.cs
@@ -27,7 +27,7 @@ namespace WiinUPro
             {
                 calibrationFiles.Add(calibration.Key, calibration.Value);
             }
-            extensionProfiles = other.extensionProfiles;
+            other.extensionProfiles.CopyTo(extensionProfiles, 0);
         }
     }
 }

--- a/WiinUPro/DevicePrefs.cs
+++ b/WiinUPro/DevicePrefs.cs
@@ -12,6 +12,7 @@ namespace WiinUPro
         public string icon;
         public bool autoConnect;
         public Dictionary<string, string> calibrationFiles = new Dictionary<string, string>();
+        public string[] extensionProfiles = new string[6];
 
         public void Copy(DevicePrefs other)
         {
@@ -26,6 +27,7 @@ namespace WiinUPro
             {
                 calibrationFiles.Add(calibration.Key, calibration.Value);
             }
+            extensionProfiles = other.extensionProfiles;
         }
     }
 }

--- a/WiinUPro/Windows/DevicePrefsWindow.xaml
+++ b/WiinUPro/Windows/DevicePrefsWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WiinUPro.Windows"
         mc:Ignorable="d"
-        Title="Device Properties" Height="300" Width="232" MinHeight="250" MinWidth="232" Background="{StaticResource BackgroundMain}">
+        Title="Device Properties" Height="345" Width="240" MinHeight="300" MinWidth="240" Background="{StaticResource BackgroundMain}">
     <Grid Background="{StaticResource BackgroundSub}" Margin="10">
         <Button x:Name="acceptBtn" Content="Accept" HorizontalAlignment="Right" Margin="0,0,10,10" Width="76" Click="acceptBtn_Click" Height="24" VerticalAlignment="Bottom" Style="{StaticResource AcceptButton}"/>
         <Button x:Name="cancelBtn" Content="Cancel" Margin="10,0,0,10" Click="cancelBtn_Click" Height="22" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="75" Style="{StaticResource WarningButton}"/>
@@ -13,13 +13,24 @@
         <Label x:Name="labelNickname" Content="Nickname:" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontWeight="Bold" Foreground="{StaticResource TextHeader}"/>
         <TextBox x:Name="nickname" Height="23" Margin="10,36,10,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Foreground="#FF444444"/>
         <CheckBox x:Name="autoConnect" Content="Auto Connect" Margin="0,16,10,0" HorizontalAlignment="Right" VerticalAlignment="Top" Style="{StaticResource CheckBoxStyle}"/>
-        <Label x:Name="lableDefaultProfile" Content="Default Profile:" HorizontalAlignment="Left" Margin="10,63,0,0" VerticalAlignment="Top" FontWeight="Bold" Foreground="{StaticResource TextHeader}"/>
+        <Label x:Name="labelDefaultProfile" Content="Default Profile:" HorizontalAlignment="Left" Margin="10,63,0,0" VerticalAlignment="Top" FontWeight="Bold" Foreground="{StaticResource TextHeader}"/>
         <TextBox x:Name="defaultProfile" Height="23" Margin="10,89,10,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Foreground="#FF444444"/>
         <Button x:Name="btnDefaultProfile" Content=". . ." HorizontalAlignment="Right" Margin="0,66,10,0" VerticalAlignment="Top" Width="32" Style="{StaticResource BasicButton}" Click="btnDefaultProfile_Click"/>
-        <Label x:Name="lableDefaultCalibrations" Content="Default Calibrations:" HorizontalAlignment="Left" Margin="10,117,0,0" VerticalAlignment="Top" FontWeight="Bold" Foreground="{StaticResource TextHeader}"/>
-        <ScrollViewer Margin="10,141,10,39" VerticalScrollBarVisibility="Auto">
+        <Label x:Name="labelDefaultCalibrations" Content="Default Calibrations:" HorizontalAlignment="Left" Margin="10,195,0,0" VerticalAlignment="Top" FontWeight="Bold" Foreground="{StaticResource TextHeader}"/>
+        <ScrollViewer x:Name="calibrationViewer" Margin="10,221,10,39" VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical" x:Name="calibrationWrap">
             </StackPanel>
         </ScrollViewer>
+        <ComboBox x:Name="comboExtProfile" Margin="12,140,0,0" VerticalAlignment="Top" SelectedIndex="0" Height="24" HorizontalAlignment="Left" Width="146" SelectionChanged="comboExtProfSelect_SelectionChanged">
+            <ComboBoxItem Content="No Extension"/>
+            <ComboBoxItem Content="Nunchuk"/>
+            <ComboBoxItem Content="Classic Controller"/>
+            <ComboBoxItem Content="Classic Controller Pro"/>
+            <ComboBoxItem Content="Guitar"/>
+            <ComboBoxItem Content="Taiko Drum"/>
+        </ComboBox>
+        <Label x:Name="labelExtProfile" Content="Extension Specific Profile:" HorizontalAlignment="Left" Margin="10,114,0,0" VerticalAlignment="Top" FontWeight="Bold" Foreground="{StaticResource TextHeader}"/>
+        <TextBox x:Name="extProfile" Height="23" Margin="10,167,10,0" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Foreground="#FF444444"/>
+        <Button x:Name="btnExtProfile" Content=". . ." HorizontalAlignment="Right" Margin="0,144,10,0" VerticalAlignment="Top" Width="32" Style="{StaticResource BasicButton}" Click="btnExtProfile_Click"/>
     </Grid>
 </Window>

--- a/WiinUPro/Windows/DevicePrefsWindow.xaml.cs
+++ b/WiinUPro/Windows/DevicePrefsWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace WiinUPro.Windows
         private DevicePrefs _modifiedPrefs;
 
         private int lastIndex;
+        private bool selectionChanged = false;
 
         protected DevicePrefsWindow()
         {
@@ -116,6 +117,7 @@ namespace WiinUPro.Windows
                 margin.Top = 140;
                 calibrationViewer.Margin = margin;
             }
+            selectionChanged = true;
         }
 
         private void FindProfile(TextBox textBox)
@@ -175,7 +177,7 @@ namespace WiinUPro.Windows
 
         private void comboExtProfSelect_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_modifiedPrefs != null)
+            if (selectionChanged)
             {
                 _modifiedPrefs.extensionProfiles[lastIndex] = extProfile.Text;
                 lastIndex = comboExtProfile.SelectedIndex;

--- a/WiinUPro/Windows/DevicePrefsWindow.xaml.cs
+++ b/WiinUPro/Windows/DevicePrefsWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NintrollerLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -24,14 +25,14 @@ namespace WiinUPro.Windows
         private DevicePrefs _modifiedPrefs;
 
         private int lastIndex;
-        private bool selectionChanged = false;
+        private bool extFunc = false;
 
         protected DevicePrefsWindow()
         {
             InitializeComponent();
         }
 
-        public DevicePrefsWindow(DevicePrefs devicePrefs, string type = null) : this()
+        public DevicePrefsWindow(DevicePrefs devicePrefs, ControllerType type = ControllerType.Other) : this()
         {
             Preferences = devicePrefs;
             deviceID.Content = devicePrefs.deviceId;
@@ -87,24 +88,20 @@ namespace WiinUPro.Windows
 
                 calibrationWrap.Children.Add(stack);
             }
-            bool wiimoteType = false;
-            if (type == "NunchukB") type = "Nunchuk";
-            string[] extTypes = new string[] { "Wiimote", "Nunchuk", "ClassicController", "ClassicControllerPro", "Guitar", "TaikoDrum" };
+            if (type == ControllerType.NunchukB) type = ControllerType.Nunchuk;
+            ControllerType[] extTypes = new ControllerType[] { ControllerType.Wiimote, ControllerType.Nunchuk, ControllerType.ClassicController, ControllerType.ClassicControllerPro, ControllerType.Guitar, ControllerType.TaikoDrum };
             for(int i = 0; i < comboExtProfile.Items.Count; i++)
             {
                 if (extTypes[i] == type)
                 {
                     comboExtProfile.SelectedIndex = i;
                     lastIndex = i;
-                    wiimoteType = true;
+                    extProfile.Text = _modifiedPrefs.extensionProfiles[lastIndex];
+                    extFunc = true;
                     break;
                 }
             }
-            if (wiimoteType)
-            {
-                extProfile.Text = _modifiedPrefs.extensionProfiles[lastIndex];
-            }
-            else
+            if (!extFunc)
             {
                 comboExtProfile.Visibility = Visibility.Hidden;
                 labelExtProfile.Visibility = Visibility.Hidden;
@@ -117,7 +114,6 @@ namespace WiinUPro.Windows
                 margin.Top = 140;
                 calibrationViewer.Margin = margin;
             }
-            selectionChanged = true;
         }
 
         private void FindProfile(TextBox textBox)
@@ -177,7 +173,7 @@ namespace WiinUPro.Windows
 
         private void comboExtProfSelect_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (selectionChanged)
+            if (extFunc)
             {
                 _modifiedPrefs.extensionProfiles[lastIndex] = extProfile.Text;
                 lastIndex = comboExtProfile.SelectedIndex;

--- a/WiinUPro/Windows/DevicePrefsWindow.xaml.cs
+++ b/WiinUPro/Windows/DevicePrefsWindow.xaml.cs
@@ -87,6 +87,7 @@ namespace WiinUPro.Windows
                 calibrationWrap.Children.Add(stack);
             }
             bool wiimoteType = false;
+            if (type == "NunchukB") type = "Nunchuk";
             string[] extTypes = new string[] { "Wiimote", "Nunchuk", "ClassicController", "ClassicControllerPro", "Guitar", "TaikoDrum" };
             for(int i = 0; i < comboExtProfile.Items.Count; i++)
             {


### PR DESCRIPTION
See the individual commits for my comments and more info. As is to be expected there's room for improvement in this code. The purpose of this functionality is to allow for quick switching of Wiimote extensions with their respective profiles being automatically loaded.